### PR TITLE
Eliminado "Emisión de obligaciones" como acto correspondiente a cargo

### DIFF
--- a/bormeparser/regex.py
+++ b/bormeparser/regex.py
@@ -87,7 +87,7 @@ def is_acto_cargo_entrante(data):
 def is_acto_cargo(data):
     """ Comprueba si es un acto que tiene como parámetro una lista de cargos """
     actos = ['Revocaciones', 'Reelecciones', 'Cancelaciones de oficio de nombramientos', 'Nombramientos',
-             'Ceses/Dimisiones', 'Emisión de obligaciones', 'Modificación de poderes']
+             'Ceses/Dimisiones', 'Modificación de poderes']
     return data in actos
 
 


### PR DESCRIPTION
Para solucionar issue #15 

Cambios:
* En bormeparser/regex.py (is_acto_cargo):
    - Eliminamos "Emisión de obligaciones" de los actos que corresponden a cargos
