### PR TITLE
Mejoras en las funciones `is_company` y `clean_empresa`

### DIFF
--- a/bormeparser/clean.py
+++ b/bormeparser/clean.py
@@ -71,7 +71,12 @@ SIGLAS = {
 # TODO: UNION TEMPORAL DE EMPRESAS LEY 18 1982 DE 26 DE MAYO
 def clean_empresa(nombre):
     nombre = nombre.rstrip(".")
-    sucursal_spain = False
+
+    if nombre.endswith(" EN LIQUIDACION"):
+        nombre = re.sub(" EN LIQUIDACION$", "", nombre)
+
+    if nombre.endswith(" SUCURSAL EN ESPAÑA"):
+        nombre = re.sub(" SUCURSAL EN ESPAÑA$", "", nombre)
 
     for sigla in SIGLAS.keys():
         regexp = " " + sigla.replace(".", "\.") + "$"

--- a/bormeparser/regex.py
+++ b/bormeparser/regex.py
@@ -111,6 +111,7 @@ def is_company(data):
     """ Comprueba si es algún tipo de sociedad o por el contrario es una persona física """
     siglas = ALL_SOCIEDADES
     siglas = list(map(lambda x: ' %s' % x, siglas))
+    data = clean_empresa(data)
     return any(data.endswith(s) for s in siglas)
 
 


### PR DESCRIPTION
Cambios para tener en cuenta casos de nombres de empresas en liquidación/sucursal en España/con siglas no "limpias" (e.g. con puntuación, "S.L").

De esta manera evitamos que se clasifiquen erróneamente como "Personas" estas empresas. 
Ejemplos en LibreBorme:
https://libreborme.net/borme/busqueda/?q=en+liquidacion&page=1&type=person
https://libreborme.net/borme/busqueda/?q=sucursal+en+espa%C3%B1a&page=1&type=person
https://libreborme.net/borme/busqueda/?q=S.L&page=1&type=person

Cambios:
* en clean.py (clean_empresa):
  - Si el nombre de la empresa acaba con "EN LIQUIDACION" o "SUCURSAL EN ESPAÑA", eliminar este término
* en regex.py (is_company):
  - Limpiar el nombre antes de decidir si es empresa o persona

